### PR TITLE
Add missing Client-ID header

### DIFF
--- a/src/TwitchClient.php
+++ b/src/TwitchClient.php
@@ -52,5 +52,6 @@ class TwitchClient extends OAuth2
     public function applyAccessTokenToRequest($request, $accessToken)
     {
         $request->getHeaders()->set('Authorization', 'Bearer '. $accessToken->getToken());
+        $request->getHeaders()->set('Client-ID', $this->clientId);
     }
 }


### PR DESCRIPTION
This missing header was causing the following error: Client ID and OAuth token do not match
Fix #1 